### PR TITLE
fix: 保证内存布局为repr(C)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub struct LSR<R: Register>(UnsafeCell<R>);
 pub struct MSR<R: Register>(UnsafeCell<R>);
 
 /// 工作状态的 uart16550 数据结构。
+#[repr(C)]
 pub struct Uart16550<R: Register> {
     rbr_thr: RBR_THR<R>, // offset = 0(0x00)
     ier: IER<R>,         // offset = 1(0x04)
@@ -146,7 +147,7 @@ impl<R: Register> Uart16550<R> {
                 break;
             }
         }
-        return count;
+        count
     }
 
     /// 从 `buf` 写入字符到发送队列，返回写入的字符数。
@@ -160,6 +161,6 @@ impl<R: Register> Uart16550<R> {
                 break;
             }
         }
-        return count;
+        count
     }
 }


### PR DESCRIPTION
默认内存布局有可能不能保证成员的顺序，会造成实际寄存器访问时次序出错；repr(C)能保证成员的内存排列顺序。PR的其它部分修复了cargo clippy的警告。