### PR TITLE
feat: implement embedded_io::{Read, Write} and embedded_hal_nb::serial::{Read, Write} for Uart16550<R>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ license = "MulanPSL-2.0 OR MIT"
 readme = "README.md"
 keywords = ["uart"]
 categories = ["embedded", "hardware-support", "no-std"]
+
+[dependencies]
+embedded-io = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ categories = ["embedded", "hardware-support", "no-std"]
 
 [dependencies]
 embedded-io = "0.6.1"
+embedded-hal-nb = "1.0.0"
+nb = "1.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,10 +183,8 @@ fn blocking_write<R: Register>(uart: &Uart16550<R>, buf: &[u8]) -> usize {
 }
 
 #[inline]
-fn blocking_flush<R: Register>(uart: &Uart16550<R>) {
-    while !uart.lsr.read().is_transmitter_empty() {
-        core::hint::spin_loop();
-    }
+fn is_transfer_complete<R: Register>(uart: &Uart16550<R>) -> bool {
+    uart.lsr.read().is_transmitter_empty()
 }
 
 impl<R: Register> embedded_io::ErrorType for Uart16550<R> {
@@ -208,6 +206,44 @@ impl<R: Register> embedded_io::Write for Uart16550<R> {
 
     #[inline]
     fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(blocking_flush(self))
+        while !is_transfer_complete(self) {
+            core::hint::spin_loop();
+        }
+        Ok(())
+    }
+}
+
+impl<R: Register> embedded_hal_nb::serial::ErrorType for Uart16550<R> {
+    type Error = core::convert::Infallible;
+}
+
+impl<R: Register> embedded_hal_nb::serial::Read for Uart16550<R> {
+    #[inline]
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+        let mut buf = [0];
+        let len = blocking_read(self, &mut buf);
+        match len {
+            0 => Err(nb::Error::WouldBlock),
+            _ => Ok(buf[0])
+        }
+    }
+}
+
+impl<R: Register> embedded_hal_nb::serial::Write for Uart16550<R> {
+    #[inline]
+    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        let len = blocking_write(self, &[word]);
+        match len {
+            0 => Err(nb::Error::WouldBlock),
+            _ => Ok(())
+        }
+    }
+
+    #[inline]
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        match is_transfer_complete(self) {
+            true => Ok(()),
+            false => Err(nb::Error::WouldBlock),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ mod mcr;
 mod msr;
 mod rbr_thr;
 
+mod traits;
+
 use core::cell::UnsafeCell;
 
 pub use fcr::{FifoControl, TriggerLevel};
@@ -185,65 +187,4 @@ fn blocking_write<R: Register>(uart: &Uart16550<R>, buf: &[u8]) -> usize {
 #[inline]
 fn is_transfer_complete<R: Register>(uart: &Uart16550<R>) -> bool {
     uart.lsr.read().is_transmitter_empty()
-}
-
-impl<R: Register> embedded_io::ErrorType for Uart16550<R> {
-    type Error = core::convert::Infallible;
-}
-
-impl<R: Register> embedded_io::Read for Uart16550<R> {
-    #[inline]
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        Ok(blocking_read(self, buf))
-    }
-}
-
-impl<R: Register> embedded_io::Write for Uart16550<R> {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        Ok(blocking_write(self, buf))
-    }
-
-    #[inline]
-    fn flush(&mut self) -> Result<(), Self::Error> {
-        while !is_transfer_complete(self) {
-            core::hint::spin_loop();
-        }
-        Ok(())
-    }
-}
-
-impl<R: Register> embedded_hal_nb::serial::ErrorType for Uart16550<R> {
-    type Error = core::convert::Infallible;
-}
-
-impl<R: Register> embedded_hal_nb::serial::Read for Uart16550<R> {
-    #[inline]
-    fn read(&mut self) -> nb::Result<u8, Self::Error> {
-        let mut buf = [0];
-        let len = blocking_read(self, &mut buf);
-        match len {
-            0 => Err(nb::Error::WouldBlock),
-            _ => Ok(buf[0])
-        }
-    }
-}
-
-impl<R: Register> embedded_hal_nb::serial::Write for Uart16550<R> {
-    #[inline]
-    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
-        let len = blocking_write(self, &[word]);
-        match len {
-            0 => Err(nb::Error::WouldBlock),
-            _ => Ok(())
-        }
-    }
-
-    #[inline]
-    fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        match is_transfer_complete(self) {
-            true => Ok(()),
-            false => Err(nb::Error::WouldBlock),
-        }
-    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,62 @@
+use crate::{blocking_read, blocking_write, is_transfer_complete, Register, Uart16550};
+
+impl<R: Register> embedded_io::ErrorType for Uart16550<R> {
+    type Error = core::convert::Infallible;
+}
+
+impl<R: Register> embedded_io::Read for Uart16550<R> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        Ok(blocking_read(self, buf))
+    }
+}
+
+impl<R: Register> embedded_io::Write for Uart16550<R> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        Ok(blocking_write(self, buf))
+    }
+
+    #[inline]
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        while !is_transfer_complete(self) {
+            core::hint::spin_loop();
+        }
+        Ok(())
+    }
+}
+
+impl<R: Register> embedded_hal_nb::serial::ErrorType for Uart16550<R> {
+    type Error = core::convert::Infallible;
+}
+
+impl<R: Register> embedded_hal_nb::serial::Read for Uart16550<R> {
+    #[inline]
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+        let mut buf = [0];
+        let len = blocking_read(self, &mut buf);
+        match len {
+            0 => Err(nb::Error::WouldBlock),
+            _ => Ok(buf[0]),
+        }
+    }
+}
+
+impl<R: Register> embedded_hal_nb::serial::Write for Uart16550<R> {
+    #[inline]
+    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        let len = blocking_write(self, &[word]);
+        match len {
+            0 => Err(nb::Error::WouldBlock),
+            _ => Ok(()),
+        }
+    }
+
+    #[inline]
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        match is_transfer_complete(self) {
+            true => Ok(()),
+            false => Err(nb::Error::WouldBlock),
+        }
+    }
+}


### PR DESCRIPTION
This pull request implements `embedded_io::{Read, Write}` and `embedded_hal_nb::serial::{Read, Write}` for `Uart16550<R>`, enabling compatibility with both synchronous and non-blocking I/O frameworks. These additions enhance the flexibility of `Uart16550<R>` for various embedded applications.

The implementation aligns with the specifications of both `embedded-io` and `embedded-hal-nb`, ensuring seamless integration and predictable behavior in supported contexts.